### PR TITLE
Fixed undefined requestId in `functions-request` task & minor changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-MUMBAI_RPC_URL="example: https://rpc-mainnet.maticvigil.com      NOTE: set MUMBAI_RPC_URL or GOERLI_RPC_URL, but not both.  Delete one of these lines"
-GOERLI_RPC_URL="example: https://goerli.infura.io/v3/1234567890  NOTE: set MUMBAI_RPC_URL or GOERLI_RPC_URL, but not both.  Delete one of these lines"
-PRIVATE_KEY="Your EVM wallet private key"
+MUMBAI_RPC_URL="https://polygon-mumbai.g.alchemy.com/v2/ExampleKey"
+GOERLI_RPC_URL="https://goerli.infura.io/v3/ExampleKey"
+PRIVATE_KEY="EVM wallet private key (Example: 6c0d*********************************************ac8da9)"
 REPORT_GAS=true
-COINMARKETCAP_API_KEY="Your coinmarketcap API key (get a free one: https://coinmarketcap.com/api/)"
+COINMARKETCAP_API_KEY="CoinMarketCap API key (Get a free one: https://coinmarketcap.com/api/)"

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,13 +4,20 @@ require("./tasks")
 require("dotenv").config()
 
 // Set one of the following RPC endpoints (required)
-const MAINNET_RPC_URL = process.env.MAINNET_RPC_URL
-const POLYGON_MAINNET_RPC_URL = process.env.POLYGON_MAINNET_RPC_URL
-const MUMBAI_RPC_URL = process.env.MUMBAI_RPC_URL
-const GOERLI_RPC_URL = process.env.GOERLI_RPC_URL
+let MAINNET_RPC_URL = process.env.MAINNET_RPC_URL
+let POLYGON_MAINNET_RPC_URL = process.env.POLYGON_MAINNET_RPC_URL
+let MUMBAI_RPC_URL = process.env.MUMBAI_RPC_URL
+let GOERLI_RPC_URL = process.env.GOERLI_RPC_URL
+
+// Ignore default values from .env.example
+if (GOERLI_RPC_URL === 'https://goerli.infura.io/v3/ExampleKey') {
+  GOERLI_RPC_URL = undefined
+}
+if (MUMBAI_RPC_URL === 'https://polygon-mumbai.g.alchemy.com/v2/ExampleKey') {
+  MUMBAI_RPC_URL = undefined
+}
 
 // Ensure one of the RPC endpoints has been set
-let setRpcUrlCount = 0
 if (!MAINNET_RPC_URL && !POLYGON_MAINNET_RPC_URL && !MUMBAI_RPC_URL && !GOERLI_RPC_URL) {
   throw Error(
     "One of the following environment variables must be set: MAINNET_RPC_URL, GOERLI_RPC_URL, POLYGON_MAINNET_RPC_URL, or MUMBAI_RPC_URL"

--- a/tasks/Functions-client/deploy.js
+++ b/tasks/Functions-client/deploy.js
@@ -32,8 +32,12 @@ task("functions-deploy-client", "Deploys the FunctionsConsumer contract").setAct
       })
       console.log("Contract verified")
     } catch (error) {
-      console.log("Error verifying contract.  Delete the ./build folder and try again.")
-      console.log(error)
+      if (!error.message.includes('Already Verified')) {
+        console.log("Error verifying contract.  Try delete the ./build folder and try again.")
+        console.log(error)
+      } else {
+        console.log("Contract already verified")
+      }
     }
   }
 

--- a/tasks/Functions-client/request.js
+++ b/tasks/Functions-client/request.js
@@ -131,8 +131,9 @@ task("functions-request", "Initiates a request from an Functions client contract
 
     // Use a promise to wait & listen for the fulfillment event before returning
     await new Promise(async (resolve, reject) => {
-      // Initate the listeners before making the request
+      let requestId
 
+      // Initate the listeners before making the request
       // Listen for fulfillment errors
       oracle.on("UserCallbackError", async (eventRequestId, msg) => {
         if (requestId == eventRequestId) {
@@ -197,7 +198,7 @@ task("functions-request", "Initiates a request from an Functions client contract
           }
         }
       )
-
+      // Initiate the on-chain request after all listeners are initalized
       console.log(`\nRequesting new data for FunctionsConsumer contract ${contractAddr} on network ${network.name}`)
       const requestTx = overrides
         ? await clientContract.executeRequest(
@@ -226,8 +227,9 @@ task("functions-request", "Initiates a request from an Functions client contract
       console.log(
         `Waiting ${VERIFICATION_BLOCK_CONFIRMATIONS} blocks for transaction ${requestTx.hash} to be confirmed...`
       )
+
       const requestTxReceipt = await requestTx.wait(VERIFICATION_BLOCK_CONFIRMATIONS)
-      const requestId = requestTxReceipt.events[2].args.id
+      requestId = requestTxReceipt.events[2].args.id
       console.log(`\nRequest ${requestId} initiated`)
       console.log(`Waiting for fulfillment...\n`)
     })


### PR DESCRIPTION
- Fixed undefined requestId in `functions-request` task
- Improved `.env.example`
- Added check for default RPC URLs from `.env`
- Removed Etherscan error message if the contract is already successfully verified