### PR TITLE
Pass requestId while emitting OCRResponse event

### DIFF
--- a/contracts/FunctionsConsumer.sol
+++ b/contracts/FunctionsConsumer.sol
@@ -17,7 +17,7 @@ contract FunctionsConsumer is FunctionsClient, ConfirmedOwner {
   bytes public latestResponse;
   bytes public latestError;
 
-  event OCRResponse(bytes result, bytes err);
+  event OCRResponse(bytes32 indexed requestId, bytes result, bytes err);
 
   /**
    * @notice Executes once when a contract is created to initialize state variables
@@ -66,6 +66,6 @@ contract FunctionsConsumer is FunctionsClient, ConfirmedOwner {
     // revert('test');
     latestResponse = response;
     latestError = err;
-    emit OCRResponse(response, err);
+    emit OCRResponse(requestId, response, err);
   }
 }


### PR DESCRIPTION
This has two advantages:

-  Suppress this compilation error:

```bash
Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
  --> contracts/FunctionsConsumer.sol:62:5:
   |
62 |     bytes32 requestId,
   |  
```
- Allow users to track the statuses of their requests