### PR TITLE
Update annotations for request's args

### DIFF
--- a/Functions-request-config.js
+++ b/Functions-request-config.js
@@ -41,7 +41,7 @@ const requestConfig = {
   // DON public key used to encrypt secrets so they are not exposed on-chain
   DONPublicKey:
     "f2f9c47363202d89aa9fa70baf783d70006fe493471ac8cfa82f1426fd09f16a5f6b32b7c4b5d5165cd147a6e513ba4c0efd39d969d6b20a8a21126f0411b9c6",
-  // args can be accessed within the source code with `args[index]` (ie: args[0])
+  // args (string only array) can be accessed within the source code with `args[index]` (ie: args[0]). 
   args: ["1", "bitcoin", "btc-bitcoin", "btc", "1000000", "450"],
   // maximum size of a response in bytes
   maxResponseBytes: 256,


### PR DESCRIPTION
Worth clarifying that args can only be strings.