### PR TITLE
Use default hardhat accounts when PK is not set

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -41,14 +41,12 @@ module.exports = {
   networks: {
     hardhat: {
       allowUnlimitedContractSize: true,
-      accounts: process.env.PRIVATE_KEY
-        ? [
-            {
-              privateKey: process.env.PRIVATE_KEY,
-              balance: "10000000000000000000000",
-            },
-          ]
-        : [],
+      accounts: process.env.PRIVATE_KEY && [
+        {
+          privateKey: process.env.PRIVATE_KEY,
+          balance: "10000000000000000000000",
+        },
+      ],
     },
     ...networks,
   },


### PR DESCRIPTION
I ran into this issue when trying to execute unit tests in GH Actions environment without PK set as env variable.

Here's the error thrown:

```
TypeError: Cannot read properties of null (reading 'sendTransaction')
   at ContractFactory.<anonymous> (node_modules/@ethersproject/contracts/src.ts/index.ts:1247:38)
   at step (node_modules/@ethersproject/contracts/lib/index.js:48:23)
   at Object.next (node_modules/@ethersproject/contracts/lib/index.js:29:53)
   at fulfilled (node_modules/@ethersproject/contracts/lib/index.js:20:58)
```