### PR TITLE
Use try-catch for sending Functions requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For other detailed tutorials and examples, check out the [Chainlink Functions Tu
 
 Install **both** of the following:
 
-- Node.js version [18.18.0](https://nodejs.org/en/download/) (or the latest release of Node.js v18 if a later one is available)
+- Node.js version [20](https://nodejs.org/en/download/)
 - Deno version [1.36](https://deno.land/manual@v1.36.4/getting_started/installation) (or the latest release of Deno v1 if a later one is available)
 
 ## Steps on live testnet

--- a/tasks/Functions-consumer/performManualUpkeep.js
+++ b/tasks/Functions-consumer/performManualUpkeep.js
@@ -21,7 +21,7 @@ task("functions-perform-upkeep", "Manually call performUpkeep in an Automation c
 
     const checkUpkeep = await autoConsumerContract.checkUpkeep(performData)
     if (!checkUpkeep.upkeepNeeded) {
-      console.log("\ncheckUpkeep returned false or reverted. Upkeep was not performed.")
+      console.log("\ncheckUpkeep returned false. Upkeep was not performed.")
       return
     }
 

--- a/tasks/Functions-consumer/performManualUpkeep.js
+++ b/tasks/Functions-consumer/performManualUpkeep.js
@@ -19,12 +19,6 @@ task("functions-perform-upkeep", "Manually call performUpkeep in an Automation c
     const autoConsumerContractFactory = await ethers.getContractFactory("AutomatedFunctionsConsumer")
     const autoConsumerContract = await autoConsumerContractFactory.attach(taskArgs.contract)
 
-    const checkUpkeep = await autoConsumerContract.checkUpkeep(performData)
-    if (!checkUpkeep.upkeepNeeded) {
-      console.log("\ncheckUpkeep returned false. Upkeep was not performed.")
-      return
-    }
-
     console.log(
       `\nCalling performUpkeep for Automation consumer contract ${taskArgs.contract} on network ${network.name}${
         taskArgs.data ? ` with data ${performData}` : ""


### PR DESCRIPTION
- This corrects a potential bug if a Functions subscription lacks the funds to send a request
- Previously, it was possible for `performUpkeep` to revert if the Functions subscription lacked funds. This meant the last upkeep time was never updated, so Automation kept retrying the upkeep and could spend all the funds in the Automation subscription.
- The `try-catch` prevents Automation from attempting repeated failed upkeeps since the last upkeep time is always updated even if the Functions request fails instead of the entire transaction reverting