### PR TITLE
PRIVATE_KEY not needed for simulation

### DIFF
--- a/networks.js
+++ b/networks.js
@@ -12,13 +12,15 @@ const DEFAULT_VERIFICATION_BLOCK_CONFIRMATIONS = 2
 const npmCommand = process.env.npm_lifecycle_event
 const isTestEnvironment = npmCommand == "test" || npmCommand == "test:unit"
 
+const isSimulation = process.argv.length === 3 && process.argv[2] === "functions-simulate-script" ? true : false
+
 // Set EVM private keys (required)
 const PRIVATE_KEY = process.env.PRIVATE_KEY
 
 // TODO @dev - set this to run the accept.js task.
 const SECOND_PRIVATE_KEY = process.env.SECOND_PRIVATE_KEY
 
-if (!isTestEnvironment && !PRIVATE_KEY) {
+if (!isTestEnvironment && !isSimulation && !PRIVATE_KEY) {
   throw Error("Set the PRIVATE_KEY environment variable with your EVM wallet private key")
 }
 


### PR DESCRIPTION
Hi team,

**ISSUE:**

1.  In a terminal, clone the [functions-hardhat-starter-kit repository](https://github.com/smartcontractkit/functions-hardhat-starter-kit) and change to the `functions-hardhat-starter-kit` directory.

    ```shell
    git clone https://github.com/smartcontractkit/functions-hardhat-starter-kit && \
    cd functions-hardhat-starter-kit
    ```

1.  Run `npm install` to install the dependencies.

    ```shell
    npm install
    ```

1. Run `npx hardhat functions-simulate-script`

    ```shell
    npx hardhat functions-simulate-script
    ```
    
 --> Error:
  
   ```text
    Please set the encryption password by running: npx env-enc set-pw
    ...
    Set the PRIVATE_KEY environment variable with your EVM wallet private key
   ```
   
**Problem:**

Users shouldn't be required to provide a `PRIVATE_KEY` to simulate a request.


  