### PR TITLE
Remove hardhat-etherscan as its been deprecated in

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -54,6 +54,16 @@ module.exports = {
       arbitrum: networks.arbitrum.verifyApiKey,
       arbitrumSepolia: networks.arbitrumSepolia.verifyApiKey,
     },
+    customChains: [
+      {
+        network: "arbitrumSepolia",
+        chainId: 421614,
+        urls: {
+          apiURL: "https://api-sepolia.arbiscan.io/api",
+          browserURL: "https://sepolia.arbiscan.io/",
+        },
+      },
+    ],
   },
   gasReporter: {
     enabled: REPORT_GAS,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "functions-hardhat-starter-kit",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tooling for interacting with Chainlink Functions",
   "scripts": {
     "prepare": "husky install",
@@ -27,7 +27,6 @@
     "@nomicfoundation/hardhat-network-helpers": "^1.0.6",
     "@nomicfoundation/hardhat-toolbox": "^2.0.0",
     "@nomiclabs/hardhat-ethers": "^2.2.2",
-    "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.3",


### PR DESCRIPTION
favour of hardhat-verify.

hardhat-toolbox includes hh-verify.

Add arb sepolia to custom networks for verification functionality.