### PR TITLE
Update actions/checkout & actions/setup-node to v4 (#215)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: "18"
           cache: "npm"
@@ -24,9 +24,9 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: "18"
           cache: "npm"

--- a/tasks/Functions-consumer/request.js
+++ b/tasks/Functions-consumer/request.js
@@ -214,7 +214,9 @@ task("functions-request", "Initiates an on-demand request from a Functions consu
     )
 
     try {
-      const NUM_CONFIRMATIONS = network.name === "localFunctionsTestnet" ? 1 : undefined // localFunctionsTestnet needs 0 or 1 confirmations to work correctly as it's local.
+      // localFunctionsTestnet needs 0 or 1 confirmations to work correctly as it's local.
+      // If on live testnet or mainnet, setting to undefined then uses the functions-toolkit default of 2 confirmations.
+      const NUM_CONFIRMATIONS = network.name === "localFunctionsTestnet" ? 1 : undefined
 
       // Get response data
       const { requestId, totalCostInJuels, responseBytesHexstring, errorString, fulfillmentCode } =

--- a/tasks/Functions-consumer/request.js
+++ b/tasks/Functions-consumer/request.js
@@ -214,9 +214,11 @@ task("functions-request", "Initiates an on-demand request from a Functions consu
     )
 
     try {
+      const NUM_CONFIRMATIONS = network.name === "localFunctionsTestnet" ? 1 : undefined // localFunctionsTestnet needs 0 or 1 confirmations to work correctly as it's local.
+
       // Get response data
       const { requestId, totalCostInJuels, responseBytesHexstring, errorString, fulfillmentCode } =
-        await responseListener.listenForResponseFromTransaction(requestTx.hash)
+        await responseListener.listenForResponseFromTransaction(requestTx.hash, undefined, NUM_CONFIRMATIONS, undefined)
 
       switch (fulfillmentCode) {
         case FulfillmentCode.FULFILLED:


### PR DESCRIPTION
on Local Functions Testnet, the functions-request HH task was hanging indefinitely and then timing out.

This was likely because the functions-toolkit package's `listenForResponseFromTransaction` had a param for min confirmations which defaults to 2.  Local Functions Testnet, as a local dev chain, is set to confirm once.